### PR TITLE
Fix advertisement approval reactions

### DIFF
--- a/example.config.json
+++ b/example.config.json
@@ -1,0 +1,40 @@
+{
+	"token": "",
+	"prefix": "!",
+	"guild": "",
+
+	"commands_channel": "",
+	"welcome_channel": "",
+	"rules_channel": "",
+	"information_channel": "",
+
+	"delete_commands": false,
+	"delete_response_secs": 6,
+
+	"mod_roles": [],
+	"regional_roles": [],
+	"open_roles": [],
+	"mod_mentionable_roles": [],
+
+	"update_interval_secs": 60,
+
+	"server_list": {
+		"channel": "",
+		"message": "",
+		"special_channel_name": true,
+		"embed_colour": 3447003
+	},
+
+	"ingame": {
+		"role": "",
+		"check_name": false
+	},
+
+	"advertise": {
+		"channel_queue": "",
+		"channel_publish": "",
+		"delete_resolved_invites": false,
+		"accept_emoji": "👍",
+		"reject_emoji": "👎"
+	}
+}

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const client = new Discord.Client({
 	intents: [
 		Discord.GatewayIntentBits.Guilds,
 		Discord.GatewayIntentBits.GuildMessages,
+		Discord.GatewayIntentBits.GuildMessageReactions,
 		Discord.GatewayIntentBits.MessageContent,
 		Discord.GatewayIntentBits.GuildMembers,
 		Discord.GatewayIntentBits.DirectMessages,

--- a/modules/advertise.js
+++ b/modules/advertise.js
@@ -68,7 +68,7 @@ module.exports.onCommand = async (message, command, args) => {
 		if (config.advertise.delete_resolved_invites) {
 			util.deleteMessage(queueMessage);
 		} else {
-			queueMessage.clearReactions();
+			queueMessage.reactions.removeAll();
 			util.editMessage(queueMessage, `${queueMessage.content}\nOutcome: ${accepted ? 'Accepted' : 'Declined'}`);
 		}
 	});


### PR DESCRIPTION
The bot lacked the `GuildMessageReactions` gateway intent and Discord.js must've removed the `.clearReactions()` Message method in a major update.

Also added an example config for anyone who wants to host this bot on their own server.